### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+scim-tables (0.5.14-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + Build-Depends: Drop versioned constraint on dpkg-dev and libscim-dev.
+    + scim-modules-table: Drop versioned constraint on scim in Replaces.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Nov 2022 01:23:56 -0000
+
 scim-tables (0.5.14-1) unstable; urgency=medium
 
   [ Tz-Huan Huang ]

--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,8 @@ Section: utils
 Priority: optional
 Maintainer: Tz-Huan Huang <tzhuan@gmail.com>
 Uploaders: Toni Mueller <toni@debian.org>, Rolf Leggewie <foss@rolf.leggewie.biz>
-Build-Depends: dpkg-dev (>= 1.13.19), debhelper (>=9), pkg-config,
- autotools-dev, gettext, intltool, libtool, libscim-dev (>= 1.4.14), sharutils
+Build-Depends: debhelper (>= 9), pkg-config,
+ autotools-dev, gettext, intltool, libtool, libscim-dev, sharutils
 Standards-Version: 3.9.6
 Vcs-Git: git://git.debian.org/git/collab-maint/scim-tables.git
 Vcs-browser: http://git.debian.org/?p=collab-maint/scim-tables.git
@@ -14,7 +14,6 @@ Package: scim-modules-table
 Architecture: any
 Depends: scim, ${shlibs:Depends}, ${misc:Depends}
 Recommends: scim-tables-zh | scim-tables-ja | scim-tables-ko | scim-tables-additional
-Replaces: scim (<< 1.2.0)
 Description: generic tables IM engine module for SCIM platform
  SCIM (Smart Common Input Method) is an input method (IM) platform.
  .


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/scim-tables/024fff42-5db2-4e4f-a51b-63ec183701df.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/7a/aff3ab9a3175e6594921a80e29aef70a4bf022.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b7/772075b09e893a419bcead382bba17889019b7.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/d6/58839fa39db054dca61b96691bb3312888a767.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/0a/a150acb6851507a575d5ca702268476a8fe824.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/10/1c0ade5af3bc37c4632943419202e52e86c284.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/49/d0204ecedd85c384ba411c29666a13f3d6d713.debug
### Control files of package scim-modules-table: lines which differ (wdiff format)
* Depends: scim, libc6 (>= [-2.33),-] {+2.34),+} libgcc-s1 (>= 3.0), libgdk-pixbuf-2.0-0 (>= 2.22.0), libglib2.0-0 (>= 2.12.0), libgtk-3-0 (>= 3.11.5), libscim8v5 (>= 1.4), libstdc++6 (>= [-11), sgml-base (>= 1.28)-] {+11)+}
* [-Replaces: scim (<< 1.2.0)-]
### Control files of package scim-modules-table-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-0aa150acb6851507a575d5ca702268476a8fe824 101c0ade5af3bc37c4632943419202e52e86c284 49d0204ecedd85c384ba411c29666a13f3d6d713-] {+7aaff3ab9a3175e6594921a80e29aef70a4bf022 b7772075b09e893a419bcead382bba17889019b7 d658839fa39db054dca61b96691bb3312888a767+}
### Control files of package scim-tables-additional: lines which differ (wdiff format)
* Depends: scim-modules-table (>= [-0.5.14-1~jan+control5), sgml-base (>= 1.28)-] {+0.5.14-2~jan+obs14)+}
### Control files of package scim-tables-ja: lines which differ (wdiff format)
* Depends: scim-modules-table (>= [-0.5.14-1~jan+control5), sgml-base (>= 1.28)-] {+0.5.14-2~jan+obs14)+}
### Control files of package scim-tables-ko: lines which differ (wdiff format)
* Depends: scim-modules-table (>= [-0.5.14-1~jan+control5), sgml-base (>= 1.28)-] {+0.5.14-2~jan+obs14)+}
### Control files of package scim-tables-zh: lines which differ (wdiff format)
* Depends: scim-modules-table (>= [-0.5.14-1~jan+control5), sgml-base (>= 1.28)-] {+0.5.14-2~jan+obs14)+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/024fff42-5db2-4e4f-a51b-63ec183701df/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/024fff42-5db2-4e4f-a51b-63ec183701df/diffoscope)).
